### PR TITLE
Purge the cache only once per deployment

### DIFF
--- a/capistrano-cloudflare.gemspec
+++ b/capistrano-cloudflare.gemspec
@@ -2,8 +2,8 @@
 require File.expand_path('../lib/capistrano/cloudflare/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Nathan L Smith"]
-  gem.email         = ["nlloyds@gmail.com"]
+  gem.authors       = ["Nathan L Smith", "Tristan D Havelick"]
+  gem.email         = ["nlloyds@gmail.com", "tristan@havelick.com"]
   gem.description   = %q{Capistrano extensions for CloudFlare}
   gem.summary       = %q{Lets you make CloudFlare API calls when deploying with Capistrano.}
   gem.homepage      = "https://github.com/cramerdev/capistrano-cloudflare"

--- a/lib/capistrano/cloudflare/version.rb
+++ b/lib/capistrano/cloudflare/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module CloudFlare
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/lib/capistrano/tasks/cloudflare.rake
+++ b/lib/capistrano/tasks/cloudflare.rake
@@ -2,7 +2,7 @@ namespace :cloudflare do
   namespace :cache do
     desc "Purge the CloudFlare cache"
     task :purge do
-      on roles(:all) do
+      run_locally do
         raise 'Missing CloudFlare configuration.' unless fetch(:cloudflare_options).respond_to?(:[])
         response = Capistrano::CloudFlare.send_request(fetch(:cloudflare_options))
         if response['result'] == 'success'


### PR DESCRIPTION
Before, the cloudflare:cache:purge task would run once for each of the
servers configured, across all roles. Really, this only needs to happen
once per deploy, so now we call the CF API only once, from the local
deployment machine.